### PR TITLE
don't check for 'use strict' because it doesn't apply to ES6

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,7 +14,6 @@
     "regexp": true,
     "undef": true,
     "unused": true,
-    "strict": true,
     "trailing": true,
     "smarttabs": true,
     "white": true

--- a/templates/common/root/src/scripts/actions/index.js
+++ b/templates/common/root/src/scripts/actions/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import Reflux from 'reflux';
 
 export var NavigationActions = Reflux.createActions({

--- a/templates/common/root/src/scripts/stores/RouterStore.js
+++ b/templates/common/root/src/scripts/stores/RouterStore.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import Reflux from 'reflux';
 
 import * as actions from "actions";

--- a/templates/common/root/src/scripts/stores/index.js
+++ b/templates/common/root/src/scripts/stores/index.js
@@ -1,3 +1,1 @@
-'use strict';
-
 export * from "./RouterStore";


### PR DESCRIPTION
ES6 modules are always strict so it doesn't make sense to declare them.

Unfortunately, since jshint doesn't understand which files are ES6 or not, it can't check that rule on the other, non-ES6 files in this project. I wonder if eslint has that ability? https://github.com/jshint/jshint/issues/1636
